### PR TITLE
Refactor Draw Movement Class

### DIFF
--- a/js/controllers/sketch-controller.js
+++ b/js/controllers/sketch-controller.js
@@ -94,20 +94,20 @@ class SketchController {
      * @param  {Movement Or Conversation Point} point
      * @param  {Integer} view
      */
-    getScaledPointValues(point, view) {
-        const pixelTime = this.mapFromTotalToPixelTime(point.time);
-        const scaledTime = this.mapFromSelectPixelToTimeline(pixelTime);
-        const [scaledXPos, scaledYPos] = this.getScaledXYPos(point.xPos, point.yPos);
-        let scaledPlanOrTimeXPos;
-        if (view === this.sk.PLAN) scaledPlanOrTimeXPos = scaledXPos;
-        else if (view === this.sk.SPACETIME) scaledPlanOrTimeXPos = scaledTime;
-        else scaledPlanOrTimeXPos = null;
+    getScaledPos(point, view) {
+        const timelineXPos = this.mapFromTotalToPixelTime(point.time);
+        const selTimelineXPos = this.mapFromSelectPixelToTimeline(timelineXPos);
+        const [floorPlanXPos, floorPlanYPos] = this.getScaledXYPos(point.xPos, point.yPos);
+        let viewXPos;
+        if (view === this.sk.PLAN) viewXPos = floorPlanXPos;
+        else if (view === this.sk.SPACETIME) viewXPos = selTimelineXPos;
+        else viewXPos = null;
         return {
-            pixelTime,
-            scaledTime,
-            scaledXPos,
-            scaledYPos,
-            scaledPlanOrTimeXPos
+            timelineXPos,
+            selTimelineXPos,
+            floorPlanXPos,
+            floorPlanYPos,
+            viewXPos
         };
     }
 
@@ -163,7 +163,7 @@ class SketchController {
      * @param  {MovementPoint} curPoint
      */
     testPointIsShowing(curPoint) {
-        return this.sk.gui.overTimelineAxis(curPoint.pixelTime) && this.sk.gui.overFloorPlan(curPoint.scaledXPos, curPoint.scaledYPos) && this.testAnimation(curPoint.pixelTime);
+        return this.sk.gui.overTimelineAxis(curPoint.timelineXPos) && this.sk.gui.overFloorPlan(curPoint.floorPlanXPos, curPoint.floorPlanYPos) && this.testAnimation(curPoint.timelineXPos);
     }
 
     /**

--- a/js/draw/draw-conversation.js
+++ b/js/draw/draw-conversation.js
@@ -21,7 +21,7 @@ class DrawConversation {
      */
     setData(path, speakerList) {
         for (const point of path.conversation) {
-            const curPoint = this.sk.sketchController.getScaledPointValues(point, null);
+            const curPoint = this.sk.sketchController.getScaledPos(point, null);
             if (this.sk.sketchController.testPointIsShowing(curPoint) && this.testSelectMode(curPoint, point)) {
                 const curSpeaker = this.getSpeakerFromSpeakerList(point.speaker, speakerList); // get speaker object from global list equivalent to the current speaker of point
                 if (this.testSpeakerToDraw(curSpeaker, path.name)) this.drawRects(point, curSpeaker.color); // draws all rects
@@ -34,9 +34,9 @@ class DrawConversation {
             case 0:
                 return true;
             case 1:
-                return this.sk.gui.overCursor(curPoint.scaledXPos, curPoint.scaledYPos);
+                return this.sk.gui.overCursor(curPoint.floorPlanXPos, curPoint.floorPlanYPos);
             case 2:
-                return this.sk.gui.overSlicer(curPoint.scaledXPos, curPoint.scaledYPos);
+                return this.sk.gui.overSlicer(curPoint.floorPlanXPos, curPoint.floorPlanYPos);
             case 3:
                 return !point.isStopped;
             case 4:
@@ -87,17 +87,17 @@ class DrawConversation {
         const rectWidth = this.sk.sketchController.mapRectInverse(this.rect.maxPixelWidth, this.rect.minPixelWidth); // map to inverse of min/max to set rectWidth based on amount of pixel time selected
         let rectLength = this.sk.textWidth(point.talkTurn);
         if (rectLength < this.rect.minPixelHeight) rectLength = this.rect.minPixelHeight; // if current turn is small set it to the minimum height
-        const curPoint = this.sk.sketchController.getScaledPointValues(point, null);
+        const curPoint = this.sk.sketchController.getScaledPos(point, null);
         let yPos;
         if (this.sk.sketchController.mode.isAlignTalk) yPos = 0; // if conversation turn positioning is at top of screen
-        else yPos = curPoint.scaledYPos - rectLength;
+        else yPos = curPoint.floorPlanYPos - rectLength;
         // ***** TEST SET TEXT
-        if (this.sk.overRect(curPoint.scaledXPos, yPos, rectWidth, rectLength)) this.recordConversationBubble(point, this.sk.PLAN); // if over plan
-        else if (this.sk.overRect(curPoint.scaledTime, yPos, rectWidth, rectLength)) this.recordConversationBubble(point, this.sk.SPACETIME); // if over spacetime
+        if (this.sk.overRect(curPoint.floorPlanXPos, yPos, rectWidth, rectLength)) this.recordConversationBubble(point, this.sk.PLAN); // if over plan
+        else if (this.sk.overRect(curPoint.selTimelineXPos, yPos, rectWidth, rectLength)) this.recordConversationBubble(point, this.sk.SPACETIME); // if over spacetime
         // ***** DRAW CUR RECT
         this.sk.fill(curColor);
-        this.sk.rect(curPoint.scaledXPos, yPos, rectWidth, rectLength); // this.sk.PLAN VIEW
-        this.sk.rect(curPoint.scaledTime, yPos, rectWidth, rectLength); // this.sk.SPACETIME VIEW
+        this.sk.rect(curPoint.floorPlanXPos, yPos, rectWidth, rectLength); // this.sk.PLAN VIEW
+        this.sk.rect(curPoint.selTimelineXPos, yPos, rectWidth, rectLength); // this.sk.SPACETIME VIEW
         this.sk.textSize(this.sk.gui.keyTextSize); // reset
     }
 

--- a/js/draw/draw-movement.js
+++ b/js/draw/draw-movement.js
@@ -24,20 +24,14 @@ class DrawMovement {
 
     setPathStyles() {
         switch (this.sk.gui.getCurSelectTab()) {
-            case 0:
-                this.setPathStrokeWeights(1, 9);
-                break;
-            case 1:
-                this.setPathStrokeWeights(1, 9);
-                break;
-            case 2:
-                this.setPathStrokeWeights(1, 9);
-                break;
             case 3:
                 this.setPathStrokeWeights(1, 0);
                 break;
             case 4:
                 this.setPathStrokeWeights(0, 9);
+                break;
+            default:
+                this.setPathStrokeWeights(1, 9);
                 break;
         }
     }

--- a/js/draw/draw-movement.js
+++ b/js/draw/draw-movement.js
@@ -55,22 +55,25 @@ class DrawMovement {
         this.sk.beginShape();
         for (let i = 1; i < movementArray.length; i++) { // Start at 1 to test cur and prior points
             const p = this.createComparePoint(view, movementArray[i], movementArray[i - 1]);
-            if (this.sk.sketchController.testPointIsShowing(p.curPos)) {
-                if (view === this.sk.SPACETIME) this.testPointForBug(p.curPoint);
-                if (this.testDrawStops(view, p.curPoint)) {
-                    if (!p.priorPoint.isStopped) this.drawStopCircle(p.curPos, shade); // only draw stopped point once
-                } else {
-                    if (this.testSelectMethod(p)) {
-                        this.drawFatLine(isFatLine, p, shade);
-                        isFatLine = true;
-                    } else {
-                        this.drawThinLine(isFatLine, p, shade);
-                        isFatLine = false;
-                    }
-                }
-            }
+            if (this.sk.sketchController.testPointIsShowing(p.curPos)) isFatLine = testComparePoint(isFatLine, p, view, shade);
         }
         this.sk.endShape(); // end shape in case still drawing
+    }
+
+    testComparePoint(isFatLine, p, view, shade) {
+        if (view === this.sk.SPACETIME) this.testPointForBug(p.curPoint);
+        if (this.testDrawStops(view, p.curPoint)) {
+            if (!p.priorPoint.isStopped) this.drawStopCircle(p.curPos, shade); // only draw stopped point once
+        } else {
+            if (this.testSelectMethod(p)) {
+                this.drawFatLine(isFatLine, p, shade);
+                isFatLine = true;
+            } else {
+                this.drawThinLine(isFatLine, p, shade);
+                isFatLine = false;
+            }
+        }
+        return isFatLine;
     }
 
     setLineStyle(lineColor) {

--- a/js/draw/draw-movement.js
+++ b/js/draw/draw-movement.js
@@ -17,8 +17,8 @@ class DrawMovement {
     setData(path) {
         this.resetBug(); // always reset bug values
         this.setPathStyles();
-        this.draw(this.sk.PLAN, path.movement, path.color);
-        this.draw(this.sk.SPACETIME, path.movement, path.color);
+        this.setDraw(this.sk.PLAN, path.movement, path.color);
+        this.setDraw(this.sk.SPACETIME, path.movement, path.color);
         if (this.bug.xPos != null) this.drawBug(path.color); // if selected, draw bug
     }
 
@@ -46,69 +46,72 @@ class DrawMovement {
      * Path is separated into segments depending on test/highlight method (e.g., stops, cursor, slicer)
      * NOTE: Due to browser drawing methods, paths must be separated/segmented to change thickness or stroke
      * @param  {Integer} view
-     * @param  {Path} path
+     * @param  {MovementPoint []} movementArray
      * @param  {Color} shade
-     * @param  {string} test
      */
-
-    // TODO: 1) change testCursor to cursorMode..., 2) create object to pass vars?
-    draw(view, movementArray, shade) {
+    setDraw(view, movementArray, shade) {
+        let isFatLine = false; // controls how line segmentation
         this.setLineStyle(shade);
-        let isThickLine = false; // mode controls how paths are segmented (begun/ended)
         this.sk.beginShape();
-        // Start at 1 to test current and prior points for drawing start/end vertices correctly
-        for (let i = 1; i < movementArray.length; i++) {
-            const curPoint = this.sk.sketchController.getScaledPos(movementArray[i], view); // get current and prior points for comparison
-            const priorPoint = this.sk.sketchController.getScaledPos(movementArray[i - 1], view);
-            if (this.sk.sketchController.testPointIsShowing(curPoint)) {
-                if (this.testFloorPlanStops(view, movementArray[i])) {
-                    if (!movementArray[i - 1].isStopped) this.drawStopCircle(curPoint, shade); // only draw stopped point once
+        for (let i = 1; i < movementArray.length; i++) { // Start at 1 to test cur and prior points
+            const p = this.createComparePoint(view, movementArray[i], movementArray[i - 1]);
+            if (this.sk.sketchController.testPointIsShowing(p.curPos)) {
+                if (view === this.sk.SPACETIME) this.testPointForBug(p.curPoint);
+                if (this.testDrawStops(view, p.curPoint)) {
+                    if (!p.priorPoint.isStopped) this.drawStopCircle(p.curPos, shade); // only draw stopped point once
                 } else {
-                    if (this.testSelectMethod(curPoint, movementArray[i])) {
-                        this.drawThickLine(isThickLine, curPoint, priorPoint, shade);
-                        isThickLine = true;
+                    if (this.testSelectMethod(p)) {
+                        this.drawFatLine(isFatLine, p, shade);
+                        isFatLine = true;
                     } else {
-                        this.drawThinLine(isThickLine, curPoint, priorPoint, shade);
-                        isThickLine = false;
+                        this.drawThinLine(isFatLine, p, shade);
+                        isFatLine = false;
                     }
                 }
-                if (view === this.sk.SPACETIME) this.testPointForBug(curPoint.selTimelineXPos, curPoint.floorPlanXPos, curPoint.floorPlanYPos);
             }
         }
         this.sk.endShape(); // end shape in case still drawing
     }
 
-    testFloorPlanStops(view, point) {
-        return view === this.sk.PLAN && point.isStopped && this.sk.gui.getCurSelectTab() !== 3;
-    }
-
-    drawStopCircle(curPoint, shade) {
-        this.sk.fill(shade);
-        this.sk.circle(curPoint.viewXPos, curPoint.floorPlanYPos, 9);
-        this.sk.noFill();
-    }
-
-    testSelectMethod(curPoint, point) {
-        if (this.sk.gui.getCurSelectTab() === 1) return this.sk.gui.overCursor(curPoint.floorPlanXPos, curPoint.floorPlanYPos);
-        else if (this.sk.gui.getCurSelectTab() === 2) return this.sk.gui.overSlicer(curPoint.floorPlanXPos, curPoint.floorPlanYPos);
-        else return point.isStopped;
-    }
-
-    drawThickLine(isThickLine, curPoint, priorPoint, shade) {
-        if (isThickLine) this.sk.vertex(curPoint.viewXPos, curPoint.floorPlanYPos); // if already drawing in highlight mode, continue it
-        else this.startNewLine(priorPoint, this.largePathWeight, shade); // if not drawing in highlight mode, begin it
-    }
-
-    drawThinLine(isThickLine, curPoint, priorPoint, shade) {
-        if (isThickLine) this.startNewLine(priorPoint, this.smallPathWeight, shade); // if drawing in highlight mode, end it
-        else this.sk.vertex(curPoint.viewXPos, curPoint.floorPlanYPos);
-    }
-
-
     setLineStyle(lineColor) {
         this.sk.strokeWeight(this.smallPathWeight);
         this.sk.stroke(lineColor);
         this.sk.noFill(); // important for curve drawing
+    }
+
+    createComparePoint(view, curPoint, priorPoint) {
+        return {
+            curPoint,
+            curPos: this.sk.sketchController.getScaledPos(curPoint, view), // get current and prior points for comparison
+            priorPoint,
+            priorPos: this.sk.sketchController.getScaledPos(priorPoint, view)
+        }
+    }
+
+    testDrawStops(view, curPoint) {
+        return (view === this.sk.PLAN && curPoint.isStopped && this.sk.gui.getCurSelectTab() !== 3);
+    }
+
+    testSelectMethod(p) {
+        if (this.sk.gui.getCurSelectTab() === 1) return this.sk.gui.overCursor(p.curPos.floorPlanXPos, p.curPos.floorPlanYPos);
+        else if (this.sk.gui.getCurSelectTab() === 2) return this.sk.gui.overSlicer(p.curPos.floorPlanXPos, p.curPos.floorPlanYPos);
+        else return p.curPoint.isStopped;
+    }
+
+    drawStopCircle(curPos, shade) {
+        this.sk.fill(shade);
+        this.sk.circle(curPos.viewXPos, curPos.floorPlanYPos, 9);
+        this.sk.noFill();
+    }
+
+    drawFatLine(isFatLine, p, shade) {
+        if (isFatLine) this.sk.vertex(p.curPos.viewXPos, p.curPos.floorPlanYPos); // if already drawing in highlight mode, continue it
+        else this.startNewLine(p.priorPoint, this.largePathWeight, shade); // if not drawing in highlight mode, begin it
+    }
+
+    drawThinLine(isFatLine, p, shade) {
+        if (isFatLine) this.startNewLine(p.priorPoint, this.smallPathWeight, shade); // if drawing in highlight mode, end it
+        else this.sk.vertex(p.curPos.viewXPos, p.curPos.floorPlanYPos);
     }
 
     /**
@@ -119,23 +122,24 @@ class DrawMovement {
      * @param  {Integer} weight
      * @param  {Color} shade
      */
-    startNewLine(scaledPoint, weight, shade) {
-        this.sk.vertex(scaledPoint.viewXPos, scaledPoint.floorPlanYPos); // draw cur point twice to mark end point
-        this.sk.vertex(scaledPoint.viewXPos, scaledPoint.floorPlanYPos);
+    startNewLine(pos, weight, shade) {
+        this.sk.vertex(pos.viewXPos, pos.floorPlanYPos); // draw cur point twice to mark end point
+        this.sk.vertex(pos.viewXPos, pos.floorPlanYPos);
         this.sk.endShape();
         this.sk.strokeWeight(weight);
         this.sk.stroke(shade);
         this.sk.beginShape();
-        this.sk.vertex(scaledPoint.viewXPos, scaledPoint.floorPlanYPos); // draw cur point twice to mark starting point
-        this.sk.vertex(scaledPoint.viewXPos, scaledPoint.floorPlanYPos);
+        this.sk.vertex(pos.viewXPos, pos.floorPlanYPos); // draw cur point twice to mark starting point
+        this.sk.vertex(pos.viewXPos, pos.floorPlanYPos);
     }
 
-    testPointForBug(scaledTimeToTest, xPos, yPos) {
-        if (this.sk.sketchController.mode.isAnimate) this.recordBug(scaledTimeToTest, xPos, yPos, null); // always return true to set last/most recent point as the bug
+    testPointForBug(curPos) {
+        const [timePos, xPos, yPos] = [curPos.selTimelineXPos, curPos.floorPlanXPos, curPos.floorPlanYPos];
+        if (this.sk.sketchController.mode.isAnimate) this.recordBug(timePos, xPos, yPos, null); // always return true to set last/most recent point as the bug
         else if (this.sk.sketchController.mode.isVideoPlay) {
             const selTime = this.sk.sketchController.mapFromVideoToSelectedTime();
-            if (this.compareValuesBySpacing(selTime, scaledTimeToTest, this.bug.lengthToCompare)) this.recordBug(scaledTimeToTest, xPos, yPos, Math.abs(selTime - scaledTimeToTest));
-        } else if (this.sk.gui.overSpaceTimeView(this.sk.mouseX, this.sk.mouseY) && this.compareValuesBySpacing(this.sk.mouseX, scaledTimeToTest, this.bug.lengthToCompare)) this.recordBug(this.sk.mouseX, xPos, yPos, Math.abs(this.sk.mouseX - scaledTimeToTest));
+            if (this.compareValuesBySpacing(selTime, timePos, this.bug.lengthToCompare)) this.recordBug(timePos, xPos, yPos, Math.abs(selTime - timePos));
+        } else if (this.sk.gui.overSpaceTimeView(this.sk.mouseX, this.sk.mouseY) && this.compareValuesBySpacing(this.sk.mouseX, timePos, this.bug.lengthToCompare)) this.recordBug(this.sk.mouseX, xPos, yPos, Math.abs(this.sk.mouseX - timePos));
     }
 
     compareValuesBySpacing(value1, value2, spacing) {

--- a/js/draw/draw-movement.js
+++ b/js/draw/draw-movement.js
@@ -61,8 +61,8 @@ class DrawMovement {
         this.resetLineStyles();
         this.sk.beginShape();
         for (let i = 1; i < movementArray.length; i++) { // Start at 1 to test cur and prior points
-            const p = this.createComparePoint(view, movementArray[i], movementArray[i - 1]);
-            if (this.sk.sketchController.testPointIsShowing(p.curPos)) isFatLine = this.testComparePoint(isFatLine, p, view);
+            const p = this.createComparePoint(view, movementArray[i], movementArray[i - 1]); // create object to hold current and prior points as well as pixel positions
+            if (this.sk.sketchController.testPointIsShowing(p.curPos)) isFatLine = this.testComparePoint(isFatLine, p, view); // test and draw point and return updated isFatLine var
         }
         this.sk.endShape(); // end shape in case still drawing
     }
@@ -76,10 +76,10 @@ class DrawMovement {
      */
     testComparePoint(isFatLine, p, view) {
         if (view === this.sk.SPACETIME) this.testPointForBug(p.curPos);
-        if (this.testDrawStops(view, p.curPoint)) {
+        if (this.testDrawFloorPlanStops(view, p.curPoint)) {
             if (!p.priorPoint.isStopped) this.drawStopCircle(p.curPos); // only draw stopped point once
         } else {
-            if (this.testSelectMethod(p)) {
+            if (this.testDrawFatLine(p)) {
                 this.drawFatLine(isFatLine, p);
                 isFatLine = true;
             } else {
@@ -89,7 +89,12 @@ class DrawMovement {
         }
         return isFatLine;
     }
-
+    /**
+     * Holds current and prior MovementPoint objects and also pixel position objects for each point
+     * @param  {Integer} view
+     * @param  {MovementPoint} curPoint 
+     * @param  {MovementPoint} priorPoint 
+     */
     createComparePoint(view, curPoint, priorPoint) {
         return {
             curPoint,
@@ -101,16 +106,16 @@ class DrawMovement {
     /**
      * Holds logic for testing whether to draw stops on the floor plan
      * @param  {Integer} view
-     * @param  {PointMovement} curPoint
+     * @param  {MovementPoint} curPoint
      */
-    testDrawStops(view, curPoint) {
+    testDrawFloorPlanStops(view, curPoint) {
         return (view === this.sk.PLAN && curPoint.isStopped && this.sk.gui.getCurSelectTab() !== 3);
     }
     /**
      * Holds logic for testing current point based on selectMode
      * @param  {ComparePoint} p
      */
-    testSelectMethod(p) {
+    testDrawFatLine(p) {
         if (this.sk.gui.getCurSelectTab() === 1) return this.sk.gui.overCursor(p.curPos.floorPlanXPos, p.curPos.floorPlanYPos);
         else if (this.sk.gui.getCurSelectTab() === 2) return this.sk.gui.overSlicer(p.curPos.floorPlanXPos, p.curPos.floorPlanYPos);
         else return p.curPoint.isStopped;

--- a/js/draw/draw-movement.js
+++ b/js/draw/draw-movement.js
@@ -64,8 +64,8 @@ class DrawMovement {
         this.sk.beginShape();
         // Start at 1 to test current and prior points for drawing start/end vertices correctly
         for (let i = 1; i < movementArray.length; i++) {
-            const curPoint = this.sk.sketchController.getScaledPointValues(movementArray[i], view); // get current and prior points for comparison
-            const priorPoint = this.sk.sketchController.getScaledPointValues(movementArray[i - 1], view);
+            const curPoint = this.sk.sketchController.getScaledPos(movementArray[i], view); // get current and prior points for comparison
+            const priorPoint = this.sk.sketchController.getScaledPos(movementArray[i - 1], view);
             if (this.sk.sketchController.testPointIsShowing(curPoint)) {
                 if (this.testFloorPlanStops(view, movementArray[i])) {
                     if (!movementArray[i - 1].isStopped) this.drawStopCircle(curPoint, shade); // only draw stopped point once
@@ -78,7 +78,7 @@ class DrawMovement {
                         isThickLine = false;
                     }
                 }
-                if (view === this.sk.SPACETIME) this.testPointForBug(curPoint.scaledTime, curPoint.scaledXPos, curPoint.scaledYPos);
+                if (view === this.sk.SPACETIME) this.testPointForBug(curPoint.selTimelineXPos, curPoint.floorPlanXPos, curPoint.floorPlanYPos);
             }
         }
         this.sk.endShape(); // end shape in case still drawing
@@ -90,24 +90,24 @@ class DrawMovement {
 
     drawStopCircle(curPoint, shade) {
         this.sk.fill(shade);
-        this.sk.circle(curPoint.scaledPlanOrTimeXPos, curPoint.scaledYPos, 9);
+        this.sk.circle(curPoint.viewXPos, curPoint.floorPlanYPos, 9);
         this.sk.noFill();
     }
 
     testSelectMethod(curPoint, point) {
-        if (this.sk.gui.getCurSelectTab() === 1) return this.sk.gui.overCursor(curPoint.scaledXPos, curPoint.scaledYPos);
-        else if (this.sk.gui.getCurSelectTab() === 2) return this.sk.gui.overSlicer(curPoint.scaledXPos, curPoint.scaledYPos);
+        if (this.sk.gui.getCurSelectTab() === 1) return this.sk.gui.overCursor(curPoint.floorPlanXPos, curPoint.floorPlanYPos);
+        else if (this.sk.gui.getCurSelectTab() === 2) return this.sk.gui.overSlicer(curPoint.floorPlanXPos, curPoint.floorPlanYPos);
         else return point.isStopped;
     }
 
     drawThickLine(isThickLine, curPoint, priorPoint, shade) {
-        if (isThickLine) this.sk.vertex(curPoint.scaledPlanOrTimeXPos, curPoint.scaledYPos); // if already drawing in highlight mode, continue it
+        if (isThickLine) this.sk.vertex(curPoint.viewXPos, curPoint.floorPlanYPos); // if already drawing in highlight mode, continue it
         else this.startNewLine(priorPoint, this.largePathWeight, shade); // if not drawing in highlight mode, begin it
     }
 
     drawThinLine(isThickLine, curPoint, priorPoint, shade) {
         if (isThickLine) this.startNewLine(priorPoint, this.smallPathWeight, shade); // if drawing in highlight mode, end it
-        else this.sk.vertex(curPoint.scaledPlanOrTimeXPos, curPoint.scaledYPos);
+        else this.sk.vertex(curPoint.viewXPos, curPoint.floorPlanYPos);
     }
 
 
@@ -121,19 +121,19 @@ class DrawMovement {
      * Ends and begins a new drawing shape
      * Draws two vertices to indicate starting and ending points
      * Sets correct strokeweight and this.sk.stroke depending on parameters for new shape
-     * @param  {Object returned from getScaledPointValues} scaledPoint
+     * @param  {Object returned from getScaledPos} scaledPoint
      * @param  {Integer} weight
      * @param  {Color} shade
      */
     startNewLine(scaledPoint, weight, shade) {
-        this.sk.vertex(scaledPoint.scaledPlanOrTimeXPos, scaledPoint.scaledYPos); // draw cur point twice to mark end point
-        this.sk.vertex(scaledPoint.scaledPlanOrTimeXPos, scaledPoint.scaledYPos);
+        this.sk.vertex(scaledPoint.viewXPos, scaledPoint.floorPlanYPos); // draw cur point twice to mark end point
+        this.sk.vertex(scaledPoint.viewXPos, scaledPoint.floorPlanYPos);
         this.sk.endShape();
         this.sk.strokeWeight(weight);
         this.sk.stroke(shade);
         this.sk.beginShape();
-        this.sk.vertex(scaledPoint.scaledPlanOrTimeXPos, scaledPoint.scaledYPos); // draw cur point twice to mark starting point
-        this.sk.vertex(scaledPoint.scaledPlanOrTimeXPos, scaledPoint.scaledYPos);
+        this.sk.vertex(scaledPoint.viewXPos, scaledPoint.floorPlanYPos); // draw cur point twice to mark starting point
+        this.sk.vertex(scaledPoint.viewXPos, scaledPoint.floorPlanYPos);
     }
 
     testPointForBug(scaledTimeToTest, xPos, yPos) {

--- a/js/draw/draw-movement.js
+++ b/js/draw/draw-movement.js
@@ -77,7 +77,7 @@ class DrawMovement {
                 if (this.highlightTestMethod(test, curPoint, movementArray[i])) {
                     isHighlightMode = this.highlightTestPassed(isHighlightMode, curPoint, priorPoint, shade);
                 } else {
-                    isHighlightMode = this.highlightTestFailed(isHighlightMode, curPoint, priorPoint, shade);
+                    isHighlightMode = this.highlightTestFailed(view, isHighlightMode, curPoint, priorPoint, shade);
                 }
             }
         }
@@ -96,9 +96,12 @@ class DrawMovement {
         return true;
     }
 
-    highlightTestFailed(isHighlightMode, curPoint, priorPoint, shade) {
-        if (isHighlightMode) this.startEndShape(priorPoint, this.smallPathWeight, shade); // if drawing in highlight mode, end it
-        else this.sk.vertex(curPoint.scaledPlanOrTimeXPos, curPoint.scaledYPos);
+    highlightTestFailed(view, isHighlightMode, curPoint, priorPoint, shade) {
+        if (isHighlightMode) {
+            // this conditional fixes safari bug when drawing stops/curves with same x/y positions in the floor plan view
+            if (view === this.sk.PLAN) this.startEndShape(curPoint, this.smallPathWeight, shade); // if drawing in highlight mode, end it
+            else this.startEndShape(priorPoint, this.smallPathWeight, shade); // if drawing in highlight mode, end it
+        } else this.sk.vertex(curPoint.scaledPlanOrTimeXPos, curPoint.scaledYPos);
         return false;
     }
 

--- a/js/gui/gui-interface.js
+++ b/js/gui/gui-interface.js
@@ -21,7 +21,7 @@ class GUI {
         this.dataPanelContainer = {
             xPos: 10,
             headerYPos: this.timelineContainer.bottom,
-            tabsYPos: this.timelineContainer.bottom + 60
+            tabsYPos: this.timelineContainer.bottom + 45
         }
         this.timeline = new TimelinePanel(this.sk, this.timelineContainer);
         this.dataPanel = new DataPanel(this.sk, this.dataPanelContainer);


### PR DESCRIPTION
Refactor main draw method into multiple methods to handle drawing, testing, and line segmentation of paths and stops to increase readability and efficiency of path drawing in browser. Fixed Safari bug when drawing lines with same x/y pixel positions by drawing single circle for each floor plan stop.